### PR TITLE
Accept LoTW's non-standard end-of-file field

### DIFF
--- a/hamutils/adif/adi.py
+++ b/hamutils/adif/adi.py
@@ -24,6 +24,8 @@ class ADIReader:
             tmp = self._readfield()
         except ParseErrorIncData:
             raise StopIteration
+        if tmp[0] == 'app_lotw_eof':
+            raise StopIteration
         res = {}
         while tmp[0] != 'eor':
             try:


### PR DESCRIPTION
ADIF files generated by Logbook of the World's "Download Report" option end with a non-standard end-of-file field (`<APP_LoTW_EOF>`), which is documented here: http://www.arrl.org/adif

When processing such a file with hamutils, the following error occurs:
```
Traceback (most recent call last):
  File "./test.py", line 8, in <module>
    for qso in adi:
  File "/home/argilo/git/hamutils/hamutils/adif/adi.py", line 34, in __next__
    tmp = self._readfield()
  File "/home/argilo/git/hamutils/hamutils/adif/adi.py", line 75, in _readfield
    raise ParseErrorIncData(self._line_num)
hamutils.adif.adi.ParseErrorIncData: Parse error: incomplete data, in line: 2890
```
To solve the problem, I've added support for this non-standard field. if it is encountered, then `StopIteration` is raised to indicate that there are no further items.