### PR TITLE
Fix that empty adif fields have no data specifier field length if no …

### DIFF
--- a/hamutils/adif/adi.py
+++ b/hamutils/adif/adi.py
@@ -268,6 +268,6 @@ class ADIWriter:
             else:
                 raw = '<%s:%d>%s' % (name, dlen, data)
         else:
-            raw = '<%s>' % name
+            raw = '<%s:0>' % name
 
         return unidecode(raw).encode('ascii')


### PR DESCRIPTION
Fix that empty adif fields have no data specifier field length if no data is present.

The previous behavior which leaves the length field empty is not compliant with the adif specification and caused issues with importing adif files to CloudLog.