### PR TITLE
Fix zero length specifier written to End of header and End of record

### DIFF
--- a/hamutils/adif/adi.py
+++ b/hamutils/adif/adi.py
@@ -267,6 +267,8 @@ class ADIWriter:
                 raw = '<%s:%d:%s>%s' % (name, dlen, data_type, data)
             else:
                 raw = '<%s:%d>%s' % (name, dlen, data)
+        elif name in {'eor','eoh'}:
+            raw = '<%s>' % name
         else:
             raw = '<%s:0>' % name
 


### PR DESCRIPTION
The fix for no length specifier for empty adif fields ends up writing End of header as `<eoh:0>` and End of record as `<eor:0>`.  This breaks opening an adi file written by hamutils in some software.  The fix is to write `<eoh>` and `<eor>`.